### PR TITLE
Updating Maps template to use translations for titles

### DIFF
--- a/dist_final/skins/neowx/maps.html.tmpl
+++ b/dist_final/skins/neowx/maps.html.tmpl
@@ -133,12 +133,12 @@
     <nav>
         <div class="container">
             <ul>
-                <li><a href="index.html">Current</a></li>
-                <li><a href="week.html">Week</a></li>
-                <li><a href="month.html">Month</a></li>
-                <li><a href="year.html">Year</a></li>
-                <li><a href="archive.html">Archive</a></li>
-                <li class="active"><a href="maps.html">Maps</a></li>
+                <li><a href="index.html">$Extras.Translation.title_current</a></li>
+                <li><a href="week.html">$Extras.Translation.title_week</a></li>
+                <li><a href="month.html">$Extras.Translation.title_month</a></li>
+                <li><a href="year.html">$Extras.Translation.title_year</a></li>
+                <li><a href="archive.html">$Extras.Translation.title_archive</a></li>
+                <li class="active"><a href="maps.html">$Extras.Translation.title_maps</a></li>
             </ul>
         </div>
     </nav>


### PR DESCRIPTION
The Maps page wasn't reflecting changes to the translation titles because of the hard coded values - all the other templates are correct (as far as I can see).