### PR TITLE
Fix a typo in the condition to display the extraTemp1 graph

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -458,7 +458,7 @@
         </div>
         #end if
 
-        #if $day.rxCheckPercent.has_data or $day.UV.has_data
+        #if $day.rxCheckPercent.has_data or $day.extraTemp1.has_data
         <div class="row gutters row-gutters">
             #if $day.rxCheckPercent.has_data
             <div class="col col-6 crd graph-crd">


### PR DESCRIPTION
This pull request fixes a typo that prohibits the extraTemp1 graph to be displayed